### PR TITLE
no more underscore

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -296,7 +296,7 @@
 
     </ul>
     <h3>Notes</h3>
-    <p>Note the [ ] and _ characters in the events to simplify Protoflux parsing.</p>
+    <p>Note the [ ] characters in the events to simplify Protoflux parsing.</p>
     <p>You can add new languages by modifying the JS and HTML files located in _internal/static and _internal/templates.
         Any BCP 47 lanuage tag Google supports should work.</p>
     <script type="text/javascript" src="/static/index.js"></script>


### PR DESCRIPTION
removed mention of no-longer-used underscores in the web interface's usage guide