### PR TITLE
Add setting to control sending of event tags

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -209,6 +209,7 @@ function changeLanguage() {
   if (micEnabled) toggleMic();
   recognition.lang = langSelect.value;
   sendEvent("[lang=" + langSelect.value + "]");
+  selectedLanguage = langSelect.value;
   saveSettings();
   const timeout = setTimeout(() => {
     if (micWasEnabled) toggleMic();

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,6 +108,13 @@
                             Enable Word Replacement
                         </label>
                     </div>
+
+                    <div>
+                        <label for="sendEventsCheckbox" class="checkbox-label">
+                            <input type="checkbox" id="sendEventsCheckbox" class="checkbox-input" checked>
+                            Enable Sending Events
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adds a checkbox that toggles if `[event]` tags are sent. For compatibility, this tag defaults to on.

While it's pretty easy to filter this out resonite-side, if you're never responding to these events it saves a few nodes of parsing work to ignore messages. Some examples of this include voice typing or subtitling systems.